### PR TITLE
If a runCmd fails, print the stdout in addition to the stderr

### DIFF
--- a/runner/index.js
+++ b/runner/index.js
@@ -28,6 +28,9 @@ class ProjectRunner {
       if (expectFail) {
         return;
       }
+      if (error.stdout) {
+        process.stderr.write(error.stdout);
+      }
       if (error.stderr) {
         process.stderr.write(error.stderr);
       }


### PR DESCRIPTION
`tsc` appears to put errors into `stdout`, so when `yarn lint` fails it
currently doesn't show the reason - just the exit code.

Include `stdout` in the piped output, but still show `stderr` last,
so it's the most-local information to devs after a failed command.