### PR TITLE
Upgrade typescript to 4.8

### DIFF
--- a/factory/templates/ts-package/package.json.hbs
+++ b/factory/templates/ts-package/package.json.hbs
@@ -20,6 +20,6 @@
     "react-dom": "^16.13.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
-    "typescript": "^3.9.2"
+    "typescript": "^4.8.0"
   }
 }

--- a/factory/templates/ts-project/packages/main/package.json
+++ b/factory/templates/ts-project/packages/main/package.json
@@ -17,6 +17,6 @@
     "react-dom": "^16.13.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
-    "typescript": "^3.9.2"
+    "typescript": "^4.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "rollup-plugin-peer-deps-external": "^2.2.2",
     "rollup-plugin-typescript2": "^0.27.0",
     "ts-loader": "^7.0.3",
-    "typescript": "^3.9.2",
+    "typescript": "^4.8.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7865,10 +7865,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^4.8.0:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 uglify-js@^3.1.4:
   version "3.9.2"


### PR DESCRIPTION
The production code that our benchmark emulates keeps an up-to-date
typescript version, so let's bump ours here.