### PR TITLE
Add project-reference-based webpack bundling

### DIFF
--- a/benchmark-bundle
+++ b/benchmark-bundle
@@ -15,6 +15,12 @@ processRunner({
         bundleTs: {
           bundleMode: 'ts-transpile',
         },
+        bundleTsProjectReferences: {
+          types: 'dist/src/index.d.ts',
+          bundleMode: 'ts-project-references',
+          projectReferences: 'enabled',
+          buildMode: 'tsc',
+        },
         bundleSucrase: {
           bundleMode: 'sucrase-transpile',
         },

--- a/factory/templates/ts-project/packages/main/webpack.config.js
+++ b/factory/templates/ts-project/packages/main/webpack.config.js
@@ -34,6 +34,19 @@ if (MODE.startsWith('ts-fork')) {
       },
     },
   });
+} else if (MODE.startsWith('ts-project-references')) {
+  rules.push({
+    test: /\.tsx?$/,
+    exclude: /node_modules/,
+    loader: 'ts-loader',
+    options: {
+      projectReferences: true,
+      compilerOptions: {
+        module: 'CommonJS',
+        emitDeclarationOnly: false,
+      },
+    },
+  });
 } else if (MODE.startsWith('esbuild-transpile')) {
   rules.push({
     test: /\.tsx?$/,


### PR DESCRIPTION
`ts-project-references` is similar to `ts-transpile` in that it uses `webpack`, `ts-loader` and `typescript`, except that it can reuse already-built typescript code.

Unfortunately, `ts-loader` and `typescript` don't allow using project references while also only transpiling at the same time. So, when bundling with `ts-project-references`, it's doing a full, slow type-checking compile.

However, its reuse of clean (unmodified), already-compiled sub-projects is slightly faster (per-sub-project) than having to transpile from scratch.

This means that in a sufficiently large composite project, making a change to a single sub-project and re-bundling is _faster_ with `ts-project-references` than `ts-transpile`.
Additionally, as a side benefit, this reuse applies to the output from regular `tsc --build` runs, so "linting" the full repo also preps it for a faster bundle as well.

_However_, first time builds become far slower.

Here's some results from a single round of testing:
```
*** FIRST BUNDLE TIME ***
bundleTs                  | avg=39617ms stdev=0
bundleTsProjectReferences | avg=184977ms stdev=0
bundleSucrase             | avg=12786ms stdev=0
bundleEsbuild             | avg=10725ms stdev=0
bundleBabel               | avg=41364ms stdev=0

*** INCREMENTAL BUNDLE TIMES ***
bundleTs                  | avg=39513ms stdev=0
bundleTsProjectReferences | avg=32015ms stdev=0
bundleSucrase             | avg=13154ms stdev=0
bundleEsbuild             | avg=11397ms stdev=0
bundleBabel               | avg=40877ms stdev=0
```